### PR TITLE
Label Fix

### DIFF
--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -22,6 +22,7 @@ export default {
   nonote: "No notes",
   refresh: "Refresh",
   editname: "Edit name",
+  editnotes: "Edit notes",
   selectedApplication: "Selected application",
   Devices: "Devices",
   homecaption: "Application selector",

--- a/src/pages/ApplicationView.vue
+++ b/src/pages/ApplicationView.vue
@@ -44,7 +44,7 @@
                     v-model="props.row.note"
                     buttons
                     @save="saveNote(props)"
-                    :title="$t('editname')"
+                    :title="$t('editnotes')"
                   >
                     <q-input v-model="props.row.note" dense autofocus counter/>
                   </q-popup-edit>


### PR DESCRIPTION
Just have seen, that the label of the Popup for Note Editing has a wrong name. Changed it to "Edit notes"